### PR TITLE
Added Nasdanika Architecture

### DIFF
--- a/index.html
+++ b/index.html
@@ -950,6 +950,9 @@
                     <div class="toolingOption toolingModelBased toolingStaticDiagrams">
                         <a href="https://supportportal.moodinternational.com/hc/en-us/articles/360015465100-MooD-and-the-C4-model" target="_blank">MooD</a>
                     </div>
+                    <div class="toolingOption toolingOpenSource toolingAsCode toolingStaticDiagrams toolingDynamicDiagrams toolingDeploymentDiagrams">
+                        <a href="https://architecture.models.nasdanika.org/references/eSubpackages/c4/index.html" target="_blank">Nasdanika Architecture</a>
+                    </div>
                     <div class="toolingOption toolingStaticDiagrams toolingDynamicDiagrams toolingDeploymentDiagrams">
                         <a href="https://stenciltown.omnigroup.com/stencils/c4/" target="_blank">OmniGraffle</a>
                     </div>


### PR DESCRIPTION
[Nasdanika Architecture model](https://architecture.models.nasdanika.org/) and its [C4 sub-package](https://architecture.models.nasdanika.org/references/eSubpackages/c4/index.html) can be used to document software architectures. 

I think it can be beneficial for the C4 model community and added Nasdanika Architecture entry to the tooling section. 
