### PR TITLE
Remove duplicate text on "Maps of your code" section

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -22,7 +22,6 @@ perhaps in the race for agility, many software development teams have lost the a
 
 ## Maps of your code
 
-Maps of your code
 The C4 model was created as a way to help software development teams describe and communicate software architecture,
 both during up-front design sessions and when retrospectively documenting an existing codebase. It's a way to create
 maps of your code, at various levels of detail, in the same way you would use something like Google Maps to zoom in


### PR DESCRIPTION
I noticed that the "Maps of your code" section started with "Maps of your code" right below the title. This didn't seem intentional, so I'm opening this PR to remove it.
![image](https://github.com/user-attachments/assets/f68748fc-1611-4b9c-9baa-b53f6bb11391)