### PR TITLE
doc: typo in recommendation on container page

### DIFF
--- a/diagrams/02-container.md
+++ b/diagrams/02-container.md
@@ -44,7 +44,7 @@ developers and operations/support staff.
 
 ## Recommended?
 
-Yes, a system context diagram is recommended for all software development teams.
+Yes, a container diagram is recommended for all software development teams.
 
 ## Notes
 


### PR DESCRIPTION
The [Recommended?](https://c4model.com/diagrams/container#recommended) section on container diagram page refers to System Context diagram when I think it should refer to Container diagram?