### PR TITLE
chore: fix lucid chart url

### DIFF
--- a/tooling.md
+++ b/tooling.md
@@ -226,7 +226,7 @@ Here's a collection of tooling that provides some degree of specific support for
         <a href="https://keadex.dev/en/projects/keadex-mina" target="_blank">Keadex Mina</a>
     </div>
     <div class="toolingOption toolingWithUI toolingDiagramming toolingStaticDiagrams toolingDynamicDiagrams toolingDeploymentDiagrams">
-        <a href="https://www.lucidchart.com/pages/templates/c-4-model-example" target="_blank">Lucidchart</a>
+        <a href="https://www.lucidchart.com/pages/templates/c4-model-example" target="_blank">Lucidchart</a>
     </div>
     <div class="toolingOption toolingWithUI toolingDiagramming toolingStaticDiagrams toolingDynamicDiagrams toolingDeploymentDiagrams">
         <a href="https://github.com/pihalve/c4model-visio-stencil" target="_blank">Microsoft Visio</a>


### PR DESCRIPTION
While I am preparing a knowledge sharing for my team, I found that Lucidchart template link is not working properly.
<img width="1725" alt="Screenshot 2024-11-13 at 10 55 51 AM" src="https://github.com/user-attachments/assets/98cf3b03-a0f9-4942-93ae-efc2c7238649">
