### PR TITLE
Rename diagrams.net to draw.io

### DIFF
--- a/tooling.md
+++ b/tooling.md
@@ -208,7 +208,7 @@ Here's a collection of tooling that provides some degree of specific support for
         <a href="https://diagrams.mingrammer.com/docs/nodes/c4" target="_blank">Diagrams</a>
     </div>
     <div class="toolingOption toolingOpenSource toolingDiagramming toolingWithUI toolingStaticDiagrams toolingDynamicDiagrams toolingDeploymentDiagrams">
-        <a href="https://www.diagrams.net/blog/c4-modelling" target="_blank">diagrams.net</a>
+        <a href="https://www.drawio.com/blog/c4-modelling" target="_blank">draw.io</a>
     </div>
     <div class="toolingOption toolingWithUI toolingDiagramming toolingStaticDiagrams toolingDynamicDiagrams toolingDeploymentDiagrams">
         <a href="https://libraries.excalidraw.com/#dmitry-burnyshev-c4-architecture" target="_blank">Excalidraw</a>


### PR DESCRIPTION
https://diagrams.net/ now redirects to https://www.drawio.com/, and it is clear on the site they are branding the tool as "draw.io", so I propose renaming it in the C4 overview to align with that.

I have meet multiple people that were confused that draw.io was not in the overview as it is the common name (I believe "diagrams.net" was a temp name during a merger).